### PR TITLE
Fix copy button overlapping with markdown code text

### DIFF
--- a/src/app/passport/[owner]/[repo]/page.tsx
+++ b/src/app/passport/[owner]/[repo]/page.tsx
@@ -417,7 +417,7 @@ export default async function PassportPage({ params }: PassportPageProps) {
 										<div className="relative">
 											<div className="absolute -inset-1 bg-gradient-to-r from-slate-600/10 to-emerald-600/10 rounded-lg blur-sm" />
 											<div className="relative bg-white/50 dark:bg-slate-800/50 backdrop-blur-sm rounded-lg p-3 font-mono text-xs border border-slate-200/50 dark:border-slate-700/50">
-												<code className="text-slate-800 dark:text-slate-200 break-all block pr-16">
+												<code className="text-slate-800 dark:text-slate-200 break-all block pr-20">
 													{badgeMarkdown}
 												</code>
 												<CopyButton text={badgeMarkdown} />


### PR DESCRIPTION
- Increased padding-right from pr-16 to pr-20 on code element
- Provides sufficient space for copy button with 'Copy' and 'Copied!' states
- Ensures both markdown code and copy button are clearly visible and accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the "Embed Your Badge" code snippet by increasing right padding, enhancing readability and preventing content from feeling cramped.
  * Provides a cleaner layout when viewing or copying the embed code, especially on narrower screens.
  * No functional changes to how badges are displayed or copied; purely a visual refinement for a more comfortable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->